### PR TITLE
exclude all files but manifest in meta-inf; update readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,17 +9,18 @@ Fork of [shadowfacts Forgelin](https://github.com/shadowfacts/Forgelin).
 ## Usage
 ```groovy
 repositories {
-	jcenter()
-	maven {
-		url "http://maven.shadowfacts.net/"
-	}
+    mavenCentral()
+    maven {
+        name = "jitpack"
+        url = "https://jitpack.io"
+    }
 }
 
 dependencies {
-	compile group: "net.shadowfacts", name: "Forgelin", version: "LATEST_VERSION"
+    compile "com.github.GTNewHorizons:Forgelin:LATEST_VERSION"
 }
 ```
 
-All versions can be seen [here](http://maven.shadowfacts.net/net/shadowfacts/Forgelin/).
+All versions can be seen [here](https://jitpack.io/#GTNewHorizons/Forgelin).
 
-**Note:** You must have the `jcenter()` call in your `repositories` block. JCenter is used to host the Kotlin coroutines libraries.
+**Note:** You must have the `mavenCentral()` call in your `repositories` block. MavenCentral is used to host the Kotlin coroutines libraries.

--- a/build.gradle
+++ b/build.gradle
@@ -70,6 +70,11 @@ jar {
 shadowJar {
 	classifier = ""
 
+	// to avoid java 9 metadata which is confusing for forge ASM reader, which expects to see only java 8 classes
+	exclude { FileTreeElement file ->
+		file.getPath().contains("META-INF") && file.name != "MANIFEST.MF"
+	}
+
 	dependencies {
 		exclude "net\\minecraftforge\\**"
 		exclude "GradleStart*"
@@ -82,10 +87,6 @@ shadowJar {
 		include(dependency("org.jetbrains.kotlinx:kotlinx-coroutines-jdk8:$coroutines_version"))
 	}
 
-	manifest {
-		attributes "FMLCorePlugin": "net.shadowfacts.forgelin.preloader.ForgelinPlugin",
-					"FMLCorePluginContainsFMLMod": "true"
-	}
 }
 
 tasks.build.dependsOn shadowJar
@@ -123,4 +124,3 @@ task signJar(dependsOn: "reobf") {
 		)
 	}
 }
-

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,4 @@
-mod_version = 1.9.1-GTNH-1.7.10-Edition
+mod_version = 1.9.2-GTNH-1.7.10-Edition
 group = net.shadowfacts
 archivesBaseName = Forgelin
 

--- a/src/main/kotlin/net/shadowfacts/forgelin/Forgelin.kt
+++ b/src/main/kotlin/net/shadowfacts/forgelin/Forgelin.kt
@@ -13,7 +13,7 @@ object Forgelin {
 
 	const val MOD_ID = "forgelin"
 	const val NAME = "Forgelin"
-	const val VERSION = "1.9.1-GTNH-1.7.10-Edition"
+	const val VERSION = "1.9.2-GTNH-1.7.10-Edition"
 
 	@Mod.EventHandler
 	fun onPreInit(event: FMLPreInitializationEvent) {


### PR DESCRIPTION
Otherwise, forge asm will complain about unreadable java 9 classes which are included by shadow jar by kotlin