### PR TITLE
Update to kotlin 1.9.24

### DIFF
--- a/addon.gradle
+++ b/addon.gradle
@@ -1,1 +1,0 @@
-apply plugin: 'org.jetbrains.kotlin.jvm'

--- a/build.gradle
+++ b/build.gradle
@@ -1,5 +1,0 @@
-//version: 1707058017
-
-plugins {
-    id 'com.gtnewhorizons.gtnhconvention'
-}

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,0 +1,4 @@
+plugins {
+    id("com.gtnewhorizons.gtnhconvention")
+    id("org.jetbrains.kotlin.jvm")
+}

--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -1,10 +1,10 @@
 // Add your dependencies here
 
 dependencies {
-    shadowImplementation("org.jetbrains.kotlin:kotlin-stdlib:1.8.0")
-    shadowImplementation("org.jetbrains.kotlin:kotlin-stdlib-jdk8:1.8.0")
-    shadowImplementation("org.jetbrains.kotlin:kotlin-reflect:1.8.0")
-    shadowImplementation("org.jetbrains:annotations")
-    shadowImplementation("org.jetbrains.kotlinx:kotlinx-coroutines-core:1.6.4")
-    shadowImplementation("org.jetbrains.kotlinx:kotlinx-coroutines-jdk8:1.6.4")
+    shadowImplementation("org.jetbrains.kotlin:kotlin-stdlib:1.9.24")
+    shadowImplementation("org.jetbrains.kotlin:kotlin-stdlib-jdk8:1.9.24")
+    shadowImplementation("org.jetbrains.kotlin:kotlin-reflect:1.9.24")
+    shadowImplementation("org.jetbrains:annotations:24.1.0")
+    shadowImplementation("org.jetbrains.kotlinx:kotlinx-coroutines-core:1.8.1")
+    shadowImplementation("org.jetbrains.kotlinx:kotlinx-coroutines-jdk8:1.8.1")
 }

--- a/gradle.properties
+++ b/gradle.properties
@@ -117,7 +117,7 @@ minimizeShadowedDependencies = false
 # If disabled, won't rename the shadowed classes.
 relocateShadowedDependencies = false
 
-# Adds the GTNH maven, CurseMaven, IC2/Player maven, and some more well-known 1.7.10 repositories.
+# Adds the GTNH maven, CurseMaven, Modrinth, and some more well-known 1.7.10 repositories.
 includeWellKnownRepositories = true
 
 # Change these to your Maven coordinates if you want to publish to a custom Maven repository instead of the default GTNH Maven.

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.6-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.7-bin.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME

--- a/settings.gradle
+++ b/settings.gradle
@@ -17,7 +17,7 @@ pluginManagement {
 }
 
 plugins {
-    id 'com.gtnewhorizons.gtnhsettingsconvention' version '1.0.14'
+    id 'com.gtnewhorizons.gtnhsettingsconvention' version '1.0.22'
 }
 
 


### PR DESCRIPTION
Updates to the latest kotlin version. There have been no binary-incompatible changes in kotlin, so it should be fine to bump: <https://kotlinlang.org/docs/compatibility-guide-19.html>