### PR TITLE
Excluded the transitive dependencies to sources

### DIFF
--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -10,10 +10,11 @@ dependencies {
     shadowImplementation("org.jetbrains:annotations:26.0.2")
     shadowImplementation("org.jetbrains.kotlinx:kotlinx-coroutines-core:1.10.1")
     shadowImplementation("org.jetbrains.kotlinx:kotlinx-coroutines-jdk8:1.10.1")
-    shadowSources("org.jetbrains.kotlin:kotlin-stdlib:2.1.10:sources")
-    shadowSources("org.jetbrains.kotlin:kotlin-stdlib-jdk8:2.1.10:sources")
-    shadowSources("org.jetbrains.kotlin:kotlin-reflect:2.1.10:sources")
-    shadowSources("org.jetbrains:annotations:26.0.2:sources")
-    shadowSources("org.jetbrains.kotlinx:kotlinx-coroutines-core:1.10.1:sources")
-    shadowSources("org.jetbrains.kotlinx:kotlinx-coroutines-jdk8:1.10.1:sources")
+
+    shadowSources("org.jetbrains.kotlin:kotlin-stdlib:2.1.10:sources") { transitive = false }
+    shadowSources("org.jetbrains.kotlin:kotlin-stdlib-jdk8:2.1.10:sources") { transitive = false }
+    shadowSources("org.jetbrains.kotlin:kotlin-reflect:2.1.10:sources") { transitive = false }
+    shadowSources("org.jetbrains:annotations:26.0.2:sources") { transitive = false }
+    shadowSources("org.jetbrains.kotlinx:kotlinx-coroutines-core:1.10.1:sources") { transitive = false }
+    shadowSources("org.jetbrains.kotlinx:kotlinx-coroutines-jdk8:1.10.1:sources") { transitive = false }
 }


### PR DESCRIPTION
Fixed the problem that the Forgelin source jar will include `.class` files from some dependencies.

Without this PR, in the project depends on Forgelin, IDEA will more likely refer to the decompiled classes, which is much worse than even not having these included.
