### PR TITLE
Added a coroutine dispatcher for server thread

### DIFF
--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -4,6 +4,7 @@ configurations {
 }
 
 dependencies {
+    compileOnly("com.github.GTNewHorizons:GTNHLib:0.6.36:dev")
     shadowImplementation("org.jetbrains.kotlin:kotlin-stdlib:2.1.10")
     shadowImplementation("org.jetbrains.kotlin:kotlin-stdlib-jdk8:2.1.10")
     shadowImplementation("org.jetbrains.kotlin:kotlin-reflect:2.1.10")

--- a/src/main/kotlin/net/shadowfacts/forgelin/coroutines/MinecraftServerDispatcher.kt
+++ b/src/main/kotlin/net/shadowfacts/forgelin/coroutines/MinecraftServerDispatcher.kt
@@ -12,7 +12,8 @@ internal val isGTNHLibLoaded by lazy { Loader.isModLoaded("gtnhlib") }
 /**
  * The dispatcher that runs the block in the server main thread.
  *
- * Note that GTNHLib is required for this dispatcher.
+ * It's based on the implementation of GTNHLib in [ServerThreadUtil]. Thus GTNHLib is required for this dispatcher.
+ * The coroutine is invoked immediately if the caller is on the server thread; otherwise, it's invoked in the next tick before the pre-tick phase.
  *
  * Also be aware that if you dispatch coroutines when the server isn't running, it throws [IllegalStateException].
  * For the details when the dispatcher is ready, see [ServerThreadUtil].
@@ -25,9 +26,5 @@ val Dispatchers.MinecraftServer: CoroutineDispatcher
 internal object MinecraftServerDispatcher : CoroutineDispatcher() {
     override fun dispatch(context: CoroutineContext, block: Runnable) {
         ServerThreadUtil.addScheduledTask(block)
-    }
-
-    override fun isDispatchNeeded(context: CoroutineContext): Boolean {
-        return !ServerThreadUtil.isCallingFromMinecraftThread()
     }
 }

--- a/src/main/kotlin/net/shadowfacts/forgelin/coroutines/MinecraftServerDispatcher.kt
+++ b/src/main/kotlin/net/shadowfacts/forgelin/coroutines/MinecraftServerDispatcher.kt
@@ -1,0 +1,33 @@
+package net.shadowfacts.forgelin.coroutines
+
+import com.gtnewhorizon.gtnhlib.util.ServerThreadUtil
+import cpw.mods.fml.common.Loader
+import kotlinx.coroutines.CoroutineDispatcher
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.Runnable
+import kotlin.coroutines.CoroutineContext
+
+internal val isGTNHLibLoaded by lazy { Loader.isModLoaded("gtnhlib") }
+
+/**
+ * The dispatcher that runs the block in the server main thread.
+ *
+ * Note that GTNHLib is required for this dispatcher.
+ *
+ * Also be aware that if you dispatch coroutines when the server isn't running, it throws [IllegalStateException].
+ * For the details when the dispatcher is ready, see [ServerThreadUtil].
+ */
+@Suppress("UnusedReceiverParameter", "unused") // use the receiver to prevent polluting the top-level functions
+val Dispatchers.MinecraftServer: CoroutineDispatcher
+    get() = if(isGTNHLibLoaded) MinecraftServerDispatcher
+    else error("GTNHLib is required for Dispatchers.MinecraftServer.")
+
+internal object MinecraftServerDispatcher : CoroutineDispatcher() {
+    override fun dispatch(context: CoroutineContext, block: Runnable) {
+        ServerThreadUtil.addScheduledTask(block)
+    }
+
+    override fun isDispatchNeeded(context: CoroutineContext): Boolean {
+        return !ServerThreadUtil.isCallingFromMinecraftThread()
+    }
+}


### PR DESCRIPTION
This feature requires GTNHLib to be installed (but optional, so that mods not using this feature are ok without GTNHLib).

This is used for mods using coroutines where they want to switch context (thread) to the server thread.

For example, I can launch a background coroutine, looping and setting the block at 0, 0, 0 to air. To prevent weird bugs caused by not doing it in the server thread, I can now use `withContext(Dispatchers.MinecraftServer) { world.setBlockToAir(0, 0, 0) }` to fix this.
For more details, see the Kotlin Coroutines documents.
